### PR TITLE
Fixes #2 - Used placeholder attribute for the note div

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             var noteDiv = document.createElement("div");
             noteDiv.setAttribute("contenteditable", true);
             noteDiv.id = "note";
-            noteDiv.className = "sticky"
+            noteDiv.className = "sticky";
             contentDiv.appendChild(noteDiv);
 
             hotkeys.filter = function(event) {
@@ -44,7 +44,8 @@
                 fs.readFile("/note", 'utf8', function(err, data) {
                     if(err) {
                         console.log("Document not found/ could not be read. New file will be created upon save.");
-                        noteDiv.textContent = nString;
+
+                        noteDiv.setAttribute("aria-placeholder", nString);
                     }
 
                     if(data) {

--- a/styles/stickystyle.css
+++ b/styles/stickystyle.css
@@ -13,3 +13,8 @@
     background: rgba(255, 255, 51, 0.8);
     box-shadow: -2px 2px 2px rgba(0,0,0,0.3);
   }
+
+
+.sticky[aria-placeholder]:empty:before {
+    content: attr(aria-placeholder);
+}


### PR DESCRIPTION
I am suggesting to improve your great note app by changing the solid text to a placeholder. This way, users don't need to delete the default message before taking their notes. 
For this purpose I changed one line on the html to add placeholder attribute instead of the default text content. Then, I needed to set up the placeholder in CSS file to make it display.

RaRe